### PR TITLE
Add pagination information

### DIFF
--- a/lib/paginate.js
+++ b/lib/paginate.js
@@ -11,8 +11,17 @@ function paginate (db, req) {
   const parsedPageNumber = parseInt(pageNumber)
 
   const offset = (parsedPageNumber - 1) * parsedPerPage
+  
+  onst total = db.length
+  const pages = parseInt(Math.ceil(total / perPage) || 1)
 
-  return slice(db, offset, offset + parsedPerPage)
+  return {
+    data: slice(db, offset, offset + parsedPerPage),
+    total: db.length,
+    per_page: parsedPerPage,
+    page: parsedPageNumber,
+    pages: pages,
+  }
 };
 
 module.exports = paginate

--- a/lib/paginate.js
+++ b/lib/paginate.js
@@ -12,7 +12,7 @@ function paginate (db, req) {
 
   const offset = (parsedPageNumber - 1) * parsedPerPage
   
-  onst total = db.length
+  const total = db.length
   const pages = parseInt(Math.ceil(total / perPage) || 1)
 
   return {


### PR DESCRIPTION
Currently it is a little difficult to deal with pagination without having extra information. This adds the total number of records, per_page number, page number, and total number of pages to the data return.